### PR TITLE
Extend agSelect2 directive to accept extra options

### DIFF
--- a/app/scripts/modules/gridz/select2.coffee
+++ b/app/scripts/modules/gridz/select2.coffee
@@ -30,12 +30,12 @@ gridz.directive "agSelect2", [
         options = angular.copy $scope.selectOptions or {}
         $scope.options = options
 
-        # read `minimumInputLength` from the attribute
+        # read `minimumInputLength` option from the attribute
+        options.minimumInputLength or= 1
         if attrs.selectMinimumInputLength?
           options.minimumInputLength = parseInt(attrs.selectMinimumInputLength)
 
         # set the default `minimumInputLength`
-        options.minimumInputLength or= 1
 
         # set the default `width
         options.width or= "resolve"
@@ -44,8 +44,6 @@ gridz.directive "agSelect2", [
         if not options.ajax? and attrs.selectAjaxUrl?
           options.ajax =
             url: pathWithContext(attrs.selectAjaxUrl)
-            # Number of milliseconds to wait for the user to stop typing before issuing the ajax request
-            quietMillis: 500
             data: (term, page) ->
               q: term # search term (query params)
               max: 20, page: page
@@ -53,6 +51,13 @@ gridz.directive "agSelect2", [
             results: (result, page) ->
               more = page < result.total
               results: result.rows, more: more
+
+          # read `quietMillis` option from the attribute
+          # Number of milliseconds to wait for the user to
+          # stop typing before issuing the ajax request
+          options.ajax.quietMillis = 500
+          if attrs.selectAjaxQuietMillis?
+            options.ajax.quietMillis = parseInt(attrs.selectAjaxQuietMillis)
 
         # create `formatResult` function from the given template
         if resultTemplate?

--- a/app/templates/partials/userSearch.html
+++ b/app/templates/partials/userSearch.html
@@ -8,6 +8,7 @@
 
             <ag-select2 select-ajax-url="/api/orgs.json"
                         select-minimum-input-length="3"
+                        select-ajax-quiet-millis="300"
                         ng-model="search.org">
               <table ag-select2-result class="table table-condensed org-select-result">
                 <tr>

--- a/test/unit/modules/gridz/select2Spec.coffee
+++ b/test/unit/modules/gridz/select2Spec.coffee
@@ -98,8 +98,6 @@ describe "module: angleGrinder.gridz, directive: agSelect2", ->
         expect(spy).toHaveBeenCalledWith "open"
 
   describe "when `selectAjaxUrl` option is provided", ->
-    ajaxOptions = null
-
     beforeEach inject (pathWithContext) ->
       pathWithContext.andReturn("/context/api/orgs.json")
 
@@ -107,18 +105,34 @@ describe "module: angleGrinder.gridz, directive: agSelect2", ->
       <ag-select2 select-ajax-url="/api/orgs.json" ng-model="search.org" />
     """
 
-    beforeEach ->
-      ajaxOptions = $directiveScope.options.ajax
+    directiveAjaxOptions = null
+    beforeEach -> directiveAjaxOptions = $directiveScope.options.ajax
 
     it "defines ajax options for handling server side lookup", ->
-      expect(ajaxOptions).toBeDefined()
+      expect(directiveAjaxOptions).toBeDefined()
 
     it "uses `pathWithContextSpy` to generate a valid path", inject (pathWithContext) ->
       expect(pathWithContext).toHaveBeenCalledWith("/api/orgs.json")
 
     it "assigns a valid server side lookup path", ->
-      expect(ajaxOptions.url).toBeDefined()
-      expect(ajaxOptions.url).toEqual "/context/api/orgs.json"
+      expect(directiveAjaxOptions.url).toBeDefined()
+      expect(directiveAjaxOptions.url).toEqual "/context/api/orgs.json"
+
+    it "assigns default `ajax.quietMillis` option", ->
+      expect(directiveAjaxOptions.quietMillis).toEqual 500
+
+  describe "when `selectAjaxUrl` options is provided along with `selectAjaxQuietMillis`", ->
+    prepareDirective """
+      <ag-select2 select-ajax-url="/api/orgs.json"
+                  select-ajax-quiet-millis="666"
+                  ng-model="search.org" />
+    """
+
+    it "ignores default value for `ajax.quietMillis` option", ->
+      expect($directiveScope.options.ajax.quietMillis).not.toEqual 500
+
+    it "assigns default `ajax.quietMillis` option", ->
+      expect($directiveScope.options.ajax.quietMillis).toEqual 666
 
   describe "when `minimumInputLength` option is provided", ->
     beforeEach -> $scope.selectOptions = minimumInputLength: 123


### PR DESCRIPTION
- [x] `minimumInputLength` option
- [x] `ajax.quietMillis` option

see: https://github.com/9ci/grails-angle-grinder/pull/37
